### PR TITLE
Revert ETags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Version History
     * All Version bumps are required to update this file as well!!
 ----
 
+* 0.8.0 - Revert ETag caching flow implementation
 * 0.7.0 - Implement ability to specify OAuth scopes
 * 0.6.1 - Update various dependencies
 * 0.6.0 - Implement ETag-based caching flow for all endpoints

--- a/cortex-client.gemspec
+++ b/cortex-client.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'faraday', '~> 0.9'
   s.add_dependency 'faraday_middleware', '~> 0.10'
-  s.add_dependency 'faraday-http-cache', '~> 1.3.0'
   s.add_dependency 'oauth2', '~> 1.1.0'
   s.add_dependency 'cortex-exceptions', '~> 0.0.4'
   s.add_dependency 'hashie', '~> 3.4'

--- a/lib/cortex/connection.rb
+++ b/lib/cortex/connection.rb
@@ -1,7 +1,6 @@
 require 'faraday'
 require 'faraday_middleware'
 require 'cortex/faraday_middleware'
-require 'faraday-http-cache'
 
 module Cortex
   module Connection
@@ -19,8 +18,6 @@ module Cortex
 
       Faraday.new options do |conn|
         conn.use Cortex::FaradayMiddleware
-
-        conn.use Faraday::HttpCache, store: Rails.cache, logger: Rails.logger if defined? Rails
         conn.request :oauth2, access_token.is_a?(OAuth2::AccessToken) ? access_token.token : access_token
         conn.request :json
         conn.response :json, :content_type => /\bjson$/

--- a/lib/cortex/version.rb
+++ b/lib/cortex/version.rb
@@ -1,3 +1,3 @@
 module Cortex
-  VERSION = '0.7.0'
+  VERSION = '0.8.0'
 end


### PR DESCRIPTION
Revert ETag caching flow implementation until cause of long-running requests can be determined