### PR TITLE
EM-835: Add encoding to Faraday

### DIFF
--- a/lib/cortex/connection.rb
+++ b/lib/cortex/connection.rb
@@ -20,6 +20,7 @@ module Cortex
         conn.use Cortex::FaradayMiddleware
         conn.request :oauth2, access_token.is_a?(OAuth2::AccessToken) ? access_token.token : access_token
         conn.request :json
+        conn.request :url_encoded
         conn.response :json, :content_type => /\bjson$/
         conn.adapter Faraday.default_adapter
       end


### PR DESCRIPTION
@toastercup @arelia @MKwenhua 

Adds url encoding to Faraday so that we can have literal parameters and not bad URI errors for promotion pages and cortex content