### PR TITLE
Basic Beta Cortex API

### DIFF
--- a/lib/cortex/client.rb
+++ b/lib/cortex/client.rb
@@ -3,6 +3,7 @@ require 'oauth2'
 require 'cortex/connection'
 require 'cortex/request'
 require 'cortex/resource'
+require 'cortex/content_items'
 require 'cortex/posts'
 require 'cortex/users'
 require 'cortex/webpages'
@@ -10,7 +11,7 @@ require 'cortex/result'
 
 module Cortex
   class Client
-    attr_reader :posts, :users, :webpages
+    attr_reader :posts, :users, :webpages, :content_items
     attr_accessor :access_token, :base_url, :auth_method
     @key = ''
     @secret = ''
@@ -32,6 +33,7 @@ module Cortex
       @posts = Cortex::Posts.new(self)
       @users = Cortex::Users.new(self)
       @webpages = Cortex::Webpages.new(self)
+      @content_items = Cortex::ContentItems.new(self)
     end
 
     def get_cc_token

--- a/lib/cortex/content_items.rb
+++ b/lib/cortex/content_items.rb
@@ -1,0 +1,27 @@
+module Cortex
+  class ContentItems  < Cortex::Resource
+    def query(params = {})
+      client.get('/content_items', params)
+    end
+
+    def feed(params = {})
+      client.get('/content_items/feed', params)
+    end
+
+    def get(id)
+      client.get("/content_items/#{id}")
+    end
+
+    def get_published(id)
+      client.get("/content_items/feed/#{id}")
+    end
+
+    def save(content_item)
+      client.save('/content_items', content_item)
+    end
+
+    def delete(id)
+      client.delete("/content_items/#{id}")
+    end
+  end
+end

--- a/lib/cortex/version.rb
+++ b/lib/cortex/version.rb
@@ -1,3 +1,3 @@
 module Cortex
-  VERSION = '0.10.2'
+  VERSION = '0.11.0'
 end


### PR DESCRIPTION
This PR implements the `ContentItems` resource, which wraps around the very rudimentary Beta Cortex RESTful API. This API will be deprecated in 2-3 quarters and replaced with the GraphQL API.